### PR TITLE
IFTAQCAB-9 Verify search buttons should not work when only one date is filled (invalid)

### DIFF
--- a/src/test/java/com/softserveinc/ita/ProtocolTest.java
+++ b/src/test/java/com/softserveinc/ita/ProtocolTest.java
@@ -47,4 +47,28 @@ public class ProtocolTest extends TestRunner {
                 .as("When both date pickers are filled correctly search button should be enabled")
                 .isTrue();
     }
+
+    @Test
+    public void verifySearchButtonIsDisabledWhenOnlyStartDateIsFilled() {
+
+        var actualResult = protocolPage
+                .chooseStartDate(parse(START_DATE))
+                .isSearchButtonEnabled();
+
+        assertThat(actualResult)
+                .as("When only start date picker is filled correctly search button should be disabled")
+                .isFalse();
+    }
+
+    @Test
+    public void verifySearchButtonIsDisabledWhenOnlyEndDateIsFilled() {
+
+        var actualResult = protocolPage
+                .chooseEndDate(parse(END_DATE))
+                .isSearchButtonEnabled();
+
+        assertThat(actualResult)
+                .as("When only end date picker is filled correctly search button should be disabled")
+                .isFalse();
+    }
 }


### PR DESCRIPTION
added tests to check search button is disabled when only one date is filled (invalid)