### PR TITLE
IFTAQCAB-32

### DIFF
--- a/src/main/java/com/softserveinc/ita/apisteps/FacultyApiStep.java
+++ b/src/main/java/com/softserveinc/ita/apisteps/FacultyApiStep.java
@@ -1,10 +1,10 @@
 package com.softserveinc.ita.apisteps;
 
 import com.softserveinc.ita.models.FacultyEntity;
-import com.softserveinc.ita.repos.FacultyRepo;
 import io.restassured.http.Cookie;
 import lombok.AllArgsConstructor;
 
+import static com.softserveinc.ita.repos.FacultyRepo.getValidRandomFaculty;
 import static com.softserveinc.ita.util.ApiUtil.createFaculty;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,15 +14,14 @@ public class FacultyApiStep {
     private Cookie sessionId;
 
     public FacultyEntity createNewFaculty() {
-        var faculty = FacultyRepo.getValidRandomFaculty();
+        var faculty = getValidRandomFaculty();
         var responseFaculty = createFaculty(faculty);
+
         assertThat(responseFaculty)
                 .as("After adding faculty with POST API it should be returned in response")
                 .hasSize(1)
                 .contains(faculty);
 
-        faculty = responseFaculty.get(0); // in order to get known given id
-        return faculty;
+        return responseFaculty.get(0); // in order to get known given id
     }
-
 }

--- a/src/main/java/com/softserveinc/ita/apisteps/FacultyApiStep.java
+++ b/src/main/java/com/softserveinc/ita/apisteps/FacultyApiStep.java
@@ -1,0 +1,28 @@
+package com.softserveinc.ita.apisteps;
+
+import com.softserveinc.ita.models.FacultyEntity;
+import com.softserveinc.ita.repos.FacultyRepo;
+import io.restassured.http.Cookie;
+import lombok.AllArgsConstructor;
+
+import static com.softserveinc.ita.util.ApiUtil.createFaculty;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@AllArgsConstructor
+public class FacultyApiStep {
+
+    private Cookie sessionId;
+
+    public FacultyEntity createNewFaculty() {
+        var faculty = FacultyRepo.getValidRandomFaculty();
+        var responseFaculty = createFaculty(faculty);
+        assertThat(responseFaculty)
+                .as("After adding faculty with POST API it should be returned in response")
+                .hasSize(1)
+                .contains(faculty);
+
+        faculty = responseFaculty.get(0); // in order to get known given id
+        return faculty;
+    }
+
+}

--- a/src/main/java/com/softserveinc/ita/apisteps/GroupsApiStep.java
+++ b/src/main/java/com/softserveinc/ita/apisteps/GroupsApiStep.java
@@ -1,0 +1,45 @@
+package com.softserveinc.ita.apisteps;
+
+import com.softserveinc.ita.models.FacultyEntity;
+import com.softserveinc.ita.models.GroupEntity;
+import com.softserveinc.ita.models.SpecialityEntity;
+import io.restassured.http.Cookie;
+import lombok.AllArgsConstructor;
+
+import static com.softserveinc.ita.util.ApiUtil.createGroup;
+import static com.softserveinc.ita.util.ApiUtil.getGroupsListByAPI;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@AllArgsConstructor
+public class GroupsApiStep {
+
+    private Cookie sessionId;
+
+    public GroupEntity createNewGroup(SpecialityEntity speciality, FacultyEntity faculty) {
+        var group = GroupEntity.getNewValidGroup(speciality, faculty);
+        var responseGroup = createGroup(group, sessionId);
+        assertThat(responseGroup)
+                .as("After adding group with POST API it should be returned in response")
+                .hasSize(1)
+                .contains(group);
+
+        group = responseGroup.get(0); // in order to get known given id
+        return group;
+    }
+
+    public GroupEntity findGroup(GroupEntity group) {
+        var groupsList = getGroupsListByAPI(sessionId);
+        assertThat(groupsList)
+                .as("List of groups returned by API should contain group")
+                .contains(group);
+        //in order to get known given id
+        return groupsList.get(groupsList.indexOf(group));
+    }
+
+    public void verifyGroupNotExist(GroupEntity group) {
+        var groupsList = getGroupsListByAPI(sessionId);
+        assertThat(groupsList)
+                .as("List of groups returned by API shouldn't contain group")
+                .doesNotContain(group);
+    }
+}

--- a/src/main/java/com/softserveinc/ita/apisteps/GroupsApiStep.java
+++ b/src/main/java/com/softserveinc/ita/apisteps/GroupsApiStep.java
@@ -6,6 +6,7 @@ import com.softserveinc.ita.models.SpecialityEntity;
 import io.restassured.http.Cookie;
 import lombok.AllArgsConstructor;
 
+import static com.softserveinc.ita.models.GroupEntity.getNewValidGroup;
 import static com.softserveinc.ita.util.ApiUtil.createGroup;
 import static com.softserveinc.ita.util.ApiUtil.getGroupsListByAPI;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,30 +17,32 @@ public class GroupsApiStep {
     private Cookie sessionId;
 
     public GroupEntity createNewGroup(SpecialityEntity speciality, FacultyEntity faculty) {
-        var group = GroupEntity.getNewValidGroup(speciality, faculty);
+        var group = getNewValidGroup(speciality, faculty);
         var responseGroup = createGroup(group, sessionId);
+
         assertThat(responseGroup)
                 .as("After adding group with POST API it should be returned in response")
                 .hasSize(1)
                 .contains(group);
 
-        group = responseGroup.get(0); // in order to get known given id
-        return group;
+        return responseGroup.get(0); // in order to get known given id
     }
 
     public GroupEntity findGroup(GroupEntity group) {
         var groupsList = getGroupsListByAPI(sessionId);
+
         assertThat(groupsList)
-                .as("List of groups returned by API should contain group")
+                .as("List of groups returned by API should contain current group")
                 .contains(group);
-        //in order to get known given id
-        return groupsList.get(groupsList.indexOf(group));
+
+        return groupsList.get(groupsList.indexOf(group)); //in order to get known given id
     }
 
     public void verifyGroupNotExist(GroupEntity group) {
         var groupsList = getGroupsListByAPI(sessionId);
+
         assertThat(groupsList)
-                .as("List of groups returned by API shouldn't contain group")
+                .as("List of groups returned by API shouldn't contain current group")
                 .doesNotContain(group);
     }
 }

--- a/src/main/java/com/softserveinc/ita/apisteps/SpecialitiesApiStep.java
+++ b/src/main/java/com/softserveinc/ita/apisteps/SpecialitiesApiStep.java
@@ -1,0 +1,43 @@
+package com.softserveinc.ita.apisteps;
+
+import com.softserveinc.ita.models.SpecialityEntity;
+import io.restassured.http.Cookie;
+import lombok.AllArgsConstructor;
+
+import static com.softserveinc.ita.util.ApiUtil.createSpeciality;
+import static com.softserveinc.ita.util.ApiUtil.getSpecialitiesListByAPI;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@AllArgsConstructor
+public class SpecialitiesApiStep {
+
+    private Cookie sessionId;
+
+    public SpecialityEntity createNewSpeciality() {
+        var speciality = SpecialityEntity.getNewValidSpeciality();
+        var responseSpeciality = createSpeciality(speciality);
+        assertThat(responseSpeciality)
+                .as("After adding speciality with API it should be returned in response")
+                .hasSize(1)
+                .contains(speciality);
+
+        speciality = responseSpeciality.get(0); // in order to get known given id
+        return speciality;
+    }
+
+    public SpecialityEntity findSpeciality(SpecialityEntity speciality) {
+        var specialitiesList = getSpecialitiesListByAPI(sessionId);
+        assertThat(specialitiesList)
+                .as("List of specialities returned by API should contain speciality")
+                .contains(speciality);
+        //in order to get known given id
+        return specialitiesList.get(specialitiesList.indexOf(speciality));
+    }
+
+    public void verifySpecialityNotExist(SpecialityEntity speciality) {
+        var specialitiesList = getSpecialitiesListByAPI(sessionId);
+        assertThat(specialitiesList)
+                .as("List of specialities returned by API shouldn't contain speciality")
+                .doesNotContain(speciality);
+    }
+}

--- a/src/main/java/com/softserveinc/ita/apisteps/SpecialitiesApiStep.java
+++ b/src/main/java/com/softserveinc/ita/apisteps/SpecialitiesApiStep.java
@@ -16,26 +16,28 @@ public class SpecialitiesApiStep {
     public SpecialityEntity createNewSpeciality() {
         var speciality = SpecialityEntity.getNewValidSpeciality();
         var responseSpeciality = createSpeciality(speciality);
+
         assertThat(responseSpeciality)
                 .as("After adding speciality with API it should be returned in response")
                 .hasSize(1)
                 .contains(speciality);
 
-        speciality = responseSpeciality.get(0); // in order to get known given id
-        return speciality;
+        return responseSpeciality.get(0); // in order to get known given id
     }
 
     public SpecialityEntity findSpeciality(SpecialityEntity speciality) {
         var specialitiesList = getSpecialitiesListByAPI(sessionId);
+
         assertThat(specialitiesList)
-                .as("List of specialities returned by API should contain speciality")
+                .as("List of specialities returned by API should contain current speciality")
                 .contains(speciality);
-        //in order to get known given id
-        return specialitiesList.get(specialitiesList.indexOf(speciality));
+
+        return specialitiesList.get(specialitiesList.indexOf(speciality)); //in order to get known given id
     }
 
     public void verifySpecialityNotExist(SpecialityEntity speciality) {
         var specialitiesList = getSpecialitiesListByAPI(sessionId);
+
         assertThat(specialitiesList)
                 .as("List of specialities returned by API shouldn't contain speciality")
                 .doesNotContain(speciality);

--- a/src/main/java/com/softserveinc/ita/models/FacultyEntity.java
+++ b/src/main/java/com/softserveinc/ita/models/FacultyEntity.java
@@ -1,12 +1,21 @@
 package com.softserveinc.ita.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Builder
 @Data
+@JsonDeserialize(builder = FacultyEntity.FacultyEntityBuilder.class)
 public class FacultyEntity {
+    @JsonProperty("faculty_id")
+    @EqualsAndHashCode.Exclude
+    private String id;
+    @JsonProperty("faculty_name")
     private String name;
+    @JsonProperty("faculty_description")
     private String description;
 }
 

--- a/src/main/java/com/softserveinc/ita/models/FacultyEntity.java
+++ b/src/main/java/com/softserveinc/ita/models/FacultyEntity.java
@@ -1,16 +1,16 @@
 package com.softserveinc.ita.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.extern.jackson.Jacksonized;
 
+@Jacksonized
 @Builder
 @Data
-@JsonDeserialize(builder = FacultyEntity.FacultyEntityBuilder.class)
 public class FacultyEntity {
-    @JsonProperty("faculty_id")
+    @JsonProperty(value = "faculty_id", access = JsonProperty.Access.WRITE_ONLY)
     @EqualsAndHashCode.Exclude
     private String id;
     @JsonProperty("faculty_name")

--- a/src/main/java/com/softserveinc/ita/models/GroupEntity.java
+++ b/src/main/java/com/softserveinc/ita/models/GroupEntity.java
@@ -2,6 +2,7 @@ package com.softserveinc.ita.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -10,7 +11,8 @@ import static com.softserveinc.ita.util.RandomUtil.getRandomStringWithNumbers;
 
 @Builder
 @Data
-@JsonDeserialize(builder = GroupEntity.GroupEntityBuilder.class)
+@JsonDeserialize(using = GroupsDeserializer.class)
+@JsonSerialize(using = GroupsSerializer.class)
 public class GroupEntity {
     @JsonProperty("group_id")
     @EqualsAndHashCode.Exclude

--- a/src/main/java/com/softserveinc/ita/models/GroupEntity.java
+++ b/src/main/java/com/softserveinc/ita/models/GroupEntity.java
@@ -1,15 +1,25 @@
 package com.softserveinc.ita.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import static com.softserveinc.ita.util.RandomUtil.getRandomStringWithNumbers;
 
 @Builder
 @Data
+@JsonDeserialize(builder = GroupEntity.GroupEntityBuilder.class)
 public class GroupEntity {
+    @JsonProperty("group_id")
+    @EqualsAndHashCode.Exclude
+    private String id;
+    @JsonProperty("group_name")
     private String name;
+    @JsonProperty("speciality_id")
     private SpecialityEntity speciality;
+    @JsonProperty("faculty_id")
     private FacultyEntity faculty;
 
     public static GroupEntity getNewValidGroup(SpecialityEntity speciality, FacultyEntity faculty) {

--- a/src/main/java/com/softserveinc/ita/models/GroupsDeserializer.java
+++ b/src/main/java/com/softserveinc/ita/models/GroupsDeserializer.java
@@ -26,7 +26,7 @@ public class GroupsDeserializer extends StdDeserializer<GroupEntity> {
         try {
             node = parser.getCodec().readTree(parser);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new AssertionError("Unable to read json with group data");
         }
 
         var group_id = node.get("group_id").asText();

--- a/src/main/java/com/softserveinc/ita/models/GroupsDeserializer.java
+++ b/src/main/java/com/softserveinc/ita/models/GroupsDeserializer.java
@@ -1,0 +1,46 @@
+package com.softserveinc.ita.models;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+public class GroupsDeserializer extends StdDeserializer<GroupEntity> {
+
+    public GroupsDeserializer() {
+        this(null);
+    }
+
+    public GroupsDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public GroupEntity deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        var group_id = node.get("group_id").asText();
+        var group_name = node.get("group_name").asText();
+        var speciality_id = node.get("speciality_id").asText();
+        var faculty_id = node.get("faculty_id").asText();
+
+        var speciality = SpecialityEntity
+                .builder()
+                .id(speciality_id)
+                .build();
+
+        var faculty = FacultyEntity
+                .builder()
+                .id(faculty_id)
+                .build();
+
+        return GroupEntity
+                .builder()
+                .id(group_id)
+                .name(group_name)
+                .speciality(speciality)
+                .faculty(faculty)
+                .build();
+    }
+}

--- a/src/main/java/com/softserveinc/ita/models/GroupsDeserializer.java
+++ b/src/main/java/com/softserveinc/ita/models/GroupsDeserializer.java
@@ -10,6 +10,9 @@ import java.io.IOException;
 public class GroupsDeserializer extends StdDeserializer<GroupEntity> {
 
     public GroupsDeserializer() {
+        //Jackson.Databind expects deserializer class to have default constructor
+        //Super class StdDeserializer doesn't have default one,
+        //so we call one of it's by calling constructor with parameter
         this(null);
     }
 
@@ -18,8 +21,14 @@ public class GroupsDeserializer extends StdDeserializer<GroupEntity> {
     }
 
     @Override
-    public GroupEntity deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-        JsonNode node = jp.getCodec().readTree(jp);
+    public GroupEntity deserialize(JsonParser parser, DeserializationContext context) {
+        JsonNode node = null;
+        try {
+            node = parser.getCodec().readTree(parser);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
         var group_id = node.get("group_id").asText();
         var group_name = node.get("group_name").asText();
         var speciality_id = node.get("speciality_id").asText();

--- a/src/main/java/com/softserveinc/ita/models/GroupsSerializer.java
+++ b/src/main/java/com/softserveinc/ita/models/GroupsSerializer.java
@@ -28,7 +28,7 @@ public class GroupsSerializer extends StdSerializer<GroupEntity> {
             jsonGenerator.writeStringField("faculty_id", group.getFaculty().getId());
             jsonGenerator.writeEndObject();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new AssertionError("Unable to serialize group");
         }
     }
 }

--- a/src/main/java/com/softserveinc/ita/models/GroupsSerializer.java
+++ b/src/main/java/com/softserveinc/ita/models/GroupsSerializer.java
@@ -9,6 +9,9 @@ import java.io.IOException;
 public class GroupsSerializer extends StdSerializer<GroupEntity> {
 
     public GroupsSerializer() {
+        //Jackson.Databind expects serializer class to have default constructor
+        //Super class StdSerializer doesn't have default one,
+        //so we call one of it's by calling constructor with parameter
         this(null);
     }
 
@@ -17,11 +20,15 @@ public class GroupsSerializer extends StdSerializer<GroupEntity> {
     }
 
     @Override
-    public void serialize(GroupEntity group, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
-        jsonGenerator.writeStartObject();
-        jsonGenerator.writeStringField("group_name", group.getName());
-        jsonGenerator.writeStringField("speciality_id", group.getSpeciality().getId());
-        jsonGenerator.writeStringField("faculty_id", group.getFaculty().getId());
-        jsonGenerator.writeEndObject();
+    public void serialize(GroupEntity group, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) {
+        try {
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField("group_name", group.getName());
+            jsonGenerator.writeStringField("speciality_id", group.getSpeciality().getId());
+            jsonGenerator.writeStringField("faculty_id", group.getFaculty().getId());
+            jsonGenerator.writeEndObject();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/com/softserveinc/ita/models/GroupsSerializer.java
+++ b/src/main/java/com/softserveinc/ita/models/GroupsSerializer.java
@@ -1,0 +1,27 @@
+package com.softserveinc.ita.models;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class GroupsSerializer extends StdSerializer<GroupEntity> {
+
+    public GroupsSerializer() {
+        this(null);
+    }
+
+    public GroupsSerializer(Class<GroupEntity> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(GroupEntity group, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField("group_name", group.getName());
+        jsonGenerator.writeStringField("speciality_id", group.getSpeciality().getId());
+        jsonGenerator.writeStringField("faculty_id", group.getFaculty().getId());
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/src/main/java/com/softserveinc/ita/models/SpecialityEntity.java
+++ b/src/main/java/com/softserveinc/ita/models/SpecialityEntity.java
@@ -1,18 +1,18 @@
 package com.softserveinc.ita.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.extern.jackson.Jacksonized;
 
 import static com.softserveinc.ita.util.RandomUtil.getRandomStringWithNumbers;
 
+@Jacksonized
 @Builder
 @Data
-@JsonDeserialize(builder = SpecialityEntity.SpecialityEntityBuilder.class)
 public class SpecialityEntity {
-    @JsonProperty("speciality_id")
+    @JsonProperty(value = "speciality_id", access = JsonProperty.Access.WRITE_ONLY)
     @EqualsAndHashCode.Exclude
     private String id;
     @JsonProperty("speciality_code")

--- a/src/main/java/com/softserveinc/ita/pageobjects/modals/AddingFormModal.java
+++ b/src/main/java/com/softserveinc/ita/pageobjects/modals/AddingFormModal.java
@@ -70,8 +70,7 @@ public class AddingFormModal {
 
     @Step("Adding form modal: wait for form closing")
     public void waitToDisappear() {
-        $x("//mat-dialog-container")
-                .should(disappear);
+        $x("//mat-dialog-container").should(disappear);
     }
 
     public AddingFormModal scrollDown(){

--- a/src/main/java/com/softserveinc/ita/pageobjects/modals/AddingFormModal.java
+++ b/src/main/java/com/softserveinc/ita/pageobjects/modals/AddingFormModal.java
@@ -57,6 +57,7 @@ public class AddingFormModal {
     public void confirmModal() {
         $x("//form//button[@type='submit' or ./span[contains(text(),'Додати')] or ./span[contains(text(),' Підтвердити ')] or ./span[contains(text(),'Confirm')]]")
                 .should(appear, ofSeconds(5))
+                .hover() //without hovering button sometimes keeps unpressed
                 .click();
     }
 
@@ -65,6 +66,12 @@ public class AddingFormModal {
         $x("//button/span[contains(text(), 'Відмінити')] | //button/span[contains(text(), 'Скасувати')] | //button/span[contains(text(), 'Cancel')] ")
                 .should(appear, ofSeconds(5))
                 .click();
+    }
+
+    @Step("Adding form modal: wait for form closing")
+    public void waitToDisappear() {
+        $x("//mat-dialog-container")
+                .should(disappear);
     }
 
     public AddingFormModal scrollDown(){

--- a/src/main/java/com/softserveinc/ita/repos/FacultyRepo.java
+++ b/src/main/java/com/softserveinc/ita/repos/FacultyRepo.java
@@ -1,6 +1,7 @@
 package com.softserveinc.ita.repos;
 
 import com.softserveinc.ita.models.FacultyEntity;
+import com.softserveinc.ita.util.RandomUtil;
 
 public class FacultyRepo {
 
@@ -25,6 +26,16 @@ public class FacultyRepo {
                 .builder()
                 .name("факультет")
                 .description("опиs факультету")
+                .build();
+    }
+
+    public static FacultyEntity getValidRandomFaculty() {
+        var randString = RandomUtil.getRandomStringWithCyrillicLetters(20);
+
+        return FacultyEntity
+                .builder()
+                .name(randString)
+                .description(randString)
                 .build();
     }
 }

--- a/src/main/java/com/softserveinc/ita/steps/GroupsStep.java
+++ b/src/main/java/com/softserveinc/ita/steps/GroupsStep.java
@@ -64,12 +64,14 @@ public class GroupsStep {
                 .getFaculty()
                 .getName();
 
-        new AddingFormModal()
+        var addingForm = new AddingFormModal();
+        addingForm
                 .setValueFor(GROUP_NAME, group.getName())
                 .setValueFor(GROUP_SPECIALTY_ID, specialityName)
                 .setValueFor(GROUP_FACULTY_ID, facultyName)
                 .confirmModal();
+        addingForm.waitToDisappear();
 
-        page.waitTillProgressBarDisappears();
+        page.waitForProgressBarToDisappear();
     }
 }

--- a/src/main/java/com/softserveinc/ita/steps/GroupsStep.java
+++ b/src/main/java/com/softserveinc/ita/steps/GroupsStep.java
@@ -3,6 +3,7 @@ package com.softserveinc.ita.steps;
 import com.softserveinc.ita.models.GroupEntity;
 import com.softserveinc.ita.pageobjects.LoginPage;
 import com.softserveinc.ita.pageobjects.admin.GroupsPage;
+import com.softserveinc.ita.pageobjects.modals.AddingFormModal;
 import com.softserveinc.ita.pageobjects.modals.DeletingFormModal;
 import lombok.Getter;
 
@@ -47,6 +48,28 @@ public class GroupsStep {
         table.deleteRowByValue(searchValue);
 
         new DeletingFormModal().confirmModal();
+        page.waitTillProgressBarDisappears();
+    }
+
+    public void editGroup(String searchValue, GroupEntity group) {
+        var table = page.getTable();
+        table.findTablePageWithSearchValue(searchValue);
+        table.editRowByValue(searchValue);
+
+        var specialityName = group
+                .getSpeciality()
+                .getName();
+
+        var facultyName = group
+                .getFaculty()
+                .getName();
+
+        new AddingFormModal()
+                .setValueFor(GROUP_NAME, group.getName())
+                .setValueFor(GROUP_SPECIALTY_ID, specialityName)
+                .setValueFor(GROUP_FACULTY_ID, facultyName)
+                .confirmModal();
+
         page.waitTillProgressBarDisappears();
     }
 }

--- a/src/main/java/com/softserveinc/ita/steps/SpecialitiesStep.java
+++ b/src/main/java/com/softserveinc/ita/steps/SpecialitiesStep.java
@@ -53,7 +53,8 @@ public class SpecialitiesStep {
         table.editRowByValue(searchValue);
 
         var addingForm = new AddingFormModal();
-        addingForm.setValueFor(SPECIALTY_NAME, speciality.getName()) //left code as it was
+        addingForm
+                .setValueFor(SPECIALTY_NAME, speciality.getName()) //left code as it was
                 .confirmModal();
         addingForm.waitToDisappear();
 

--- a/src/main/java/com/softserveinc/ita/steps/SpecialitiesStep.java
+++ b/src/main/java/com/softserveinc/ita/steps/SpecialitiesStep.java
@@ -52,10 +52,11 @@ public class SpecialitiesStep {
         table.findTablePageWithSearchValue(searchValue);
         table.editRowByValue(searchValue);
 
-        new AddingFormModal()
-                .setValueFor(SPECIALTY_NAME, speciality.getName()) //left code as it was
+        var addingForm = new AddingFormModal();
+        addingForm.setValueFor(SPECIALTY_NAME, speciality.getName()) //left code as it was
                 .confirmModal();
+        addingForm.waitToDisappear();
 
-        page.waitTillProgressBarDisappears();
+        page.waitForProgressBarToDisappear();
     }
 }

--- a/src/main/java/com/softserveinc/ita/util/ApiUtil.java
+++ b/src/main/java/com/softserveinc/ita/util/ApiUtil.java
@@ -1,5 +1,6 @@
 package com.softserveinc.ita.util;
 
+import com.softserveinc.ita.models.GroupEntity;
 import com.softserveinc.ita.models.SpecialityEntity;
 import com.softserveinc.ita.models.SubjectEntity;
 import com.softserveinc.ita.models.TimeTableEntity;
@@ -45,10 +46,7 @@ public class ApiUtil {
     }
 
     public static List<SubjectEntity> getSubjectsListByAPI(Cookie sessionId) {
-        var path = format(API_ENTITY_GET_RECORDS_PATH, "Subject");
-        var response = performGetRequest(sessionId, path);
-
-        return extractFromJson(response).getList("", SubjectEntity.class);
+        return getEntitiesListByAPI(sessionId, SubjectEntity.class);
     }
 
     public static List<SubjectEntity> postSubject(SubjectEntity subject) {
@@ -92,10 +90,21 @@ public class ApiUtil {
     }
 
     public static List<SpecialityEntity> getSpecialitiesListByAPI(Cookie sessionId) {
-        var path = format(API_ENTITY_GET_RECORDS_PATH, "Speciality");
+        return getEntitiesListByAPI(sessionId, SpecialityEntity.class);
+    }
+
+    public static List<GroupEntity> getGroupsListByAPI(Cookie sessionId) {
+        return getEntitiesListByAPI(sessionId, GroupEntity.class);
+    }
+
+    private static <T> List<T> getEntitiesListByAPI(Cookie sessionId, Class<T> genericType) {
+        var classname = genericType
+                .getSimpleName()
+                .replace("Entity", "");
+        var path = format(API_ENTITY_GET_RECORDS_PATH, classname);
         var response = performGetRequest(sessionId, path);
 
-        return extractFromJson(response).getList("", SpecialityEntity.class);
+        return extractFromJson(response).getList("", genericType);
     }
 
     private Map<String, String> setUpSubjectBody(SubjectEntity subject) {

--- a/src/main/java/com/softserveinc/ita/util/ApiUtil.java
+++ b/src/main/java/com/softserveinc/ita/util/ApiUtil.java
@@ -56,16 +56,19 @@ public class ApiUtil {
 
     public static List<SubjectEntity> postSubject(SubjectEntity subject) {
         var bodyContent = setUpSubjectBody(subject);
+
         return createEntity(bodyContent, SubjectEntity.class);
     }
 
     public static List<SpecialityEntity> createSpeciality(SpecialityEntity speciality) {
         var bodyContent = setUpSpecialityBody(speciality);
+
         return createEntity(bodyContent, SpecialityEntity.class);
     }
 
     public static List<FacultyEntity> createFaculty(FacultyEntity faculty) {
         var bodyContent = setUpFacultyBody(faculty);
+
         return createEntity(bodyContent, FacultyEntity.class);
     }
 
@@ -99,6 +102,7 @@ public class ApiUtil {
 
     public static List<TimeTableEntity> postTimeTable(TimeTableEntity timeTable) {
         var bodyContent = setUpTimeTableBody(timeTable);
+
         return createEntity(bodyContent, TimeTableEntity.class);
     }
 

--- a/src/main/java/com/softserveinc/ita/util/ApiUtil.java
+++ b/src/main/java/com/softserveinc/ita/util/ApiUtil.java
@@ -1,12 +1,10 @@
 package com.softserveinc.ita.util;
 
-import com.softserveinc.ita.models.GroupEntity;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import com.softserveinc.ita.models.SpecialityEntity;
-import com.softserveinc.ita.models.SubjectEntity;
-import com.softserveinc.ita.models.TestEntity;
-import com.softserveinc.ita.models.TimeTableEntity;
+import com.softserveinc.ita.models.*;
 import io.qameta.allure.restassured.AllureRestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
@@ -19,6 +17,7 @@ import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import lombok.experimental.UtilityClass;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -30,11 +29,12 @@ import static io.restassured.http.ContentType.JSON;
 import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
 import static java.lang.String.format;
 import static java.util.Map.of;
+import static java.util.Objects.nonNull;
 
 @UtilityClass
 public class ApiUtil {
 
-    public static Response performPostRequestWithBody(Map<String, String> bodyContent, String basePath) {
+    public static Response performPostRequestWithBody(Object bodyContent, String basePath) {
         setUpApiSpecifications();
 
         return given()
@@ -55,43 +55,63 @@ public class ApiUtil {
     }
 
     public static List<SubjectEntity> postSubject(SubjectEntity subject) {
-        var path = format(API_ENTITY_POST_RECORDS_PATH, "Subject");
-        var response = performPostRequestWithBody(setUpSubjectBody(subject), path);
+        var bodyContent = setUpSubjectBody(subject);
+        return createEntity(bodyContent, SubjectEntity.class);
+    }
 
-        return extractFromJson(response).getList("", SubjectEntity.class);
+    public static List<SpecialityEntity> createSpeciality(SpecialityEntity speciality) {
+        var bodyContent = setUpSpecialityBody(speciality);
+        return createEntity(bodyContent, SpecialityEntity.class);
+    }
+
+    public static List<FacultyEntity> createFaculty(FacultyEntity faculty) {
+        var bodyContent = setUpFacultyBody(faculty);
+        return createEntity(bodyContent, FacultyEntity.class);
+    }
+
+    public static List<GroupEntity> createGroup(GroupEntity group, Cookie sessionId) {
+        var bodyContent = setUpGroupBody(group);
+        var groups = createEntity(bodyContent, GroupEntity.class);
+        fillConnectedEntitiesDataForGroupsList(sessionId, groups);
+
+        return groups;
     }
 
     public static Response deleteSubject(Cookie sessionId, SubjectEntity subject) {
-        var path = format(API_ENTITY_DELETE_RECORDS_PATH, "Subject", subject.getId());
+        return deleteEntity(subject.getId(), sessionId, subject.getClass());
+    }
 
-        return performGetRequest(sessionId, path);
+    public static Response deleteSpeciality(Cookie sessionId, SpecialityEntity speciality) {
+        return deleteEntity(speciality.getId(), sessionId, speciality.getClass());
+    }
+
+    public static Response deleteFaculty(Cookie sessionId, FacultyEntity faculty) {
+        return deleteEntity(faculty.getId(), sessionId, faculty.getClass());
+    }
+
+    public static Response deleteGroup(Cookie sessionId, GroupEntity group) {
+        return deleteEntity(group.getId(), sessionId, group.getClass());
     }
 
     public static List<TimeTableEntity> getTimeTablesListByAPI(Cookie sessionId) {
-        var path = format(API_ENTITY_GET_RECORDS_PATH, "TimeTable");
-        var response = performGetRequest(sessionId, path);
-
-        return extractFromJson(response).getList("", TimeTableEntity.class);
+        return getEntitiesListByAPI(sessionId, TimeTableEntity.class);
     }
 
     public static List<TimeTableEntity> postTimeTable(TimeTableEntity timeTable) {
-        var path = format(API_ENTITY_POST_RECORDS_PATH, "TimeTable");
-        var response = performPostRequestWithBody(setUpTimeTableBody(timeTable), path);
-
-        return extractFromJson(response).getList("", TimeTableEntity.class);
+        var bodyContent = setUpTimeTableBody(timeTable);
+        return createEntity(bodyContent, TimeTableEntity.class);
     }
 
     public static List<TimeTableEntity> updateTimeTable(TimeTableEntity timeTable) {
-        var path = format(API_ENTITY_UPDATE_RECORDS_PATH, "TimeTable", timeTable.getId());
+        var path = getPathStringByEntityClass(API_ENTITY_UPDATE_RECORDS_PATH, TimeTableEntity.class);
+        path = format(path, timeTable.getId());
         var response = performPostRequestWithBody(setUpTimeTableBody(timeTable), path);
 
         return extractFromJson(response).getList("", TimeTableEntity.class);
     }
 
     public static Response deleteTimeTable(Cookie sessionId, TimeTableEntity timeTable) {
-        var path = format(API_ENTITY_DELETE_RECORDS_PATH, "TimeTable", timeTable.getId());
-
-        return performGetRequest(sessionId, path);
+        return deleteEntity(timeTable.getId(), sessionId, timeTable.getClass());
     }
 
     public static List<SpecialityEntity> getSpecialitiesListByAPI(Cookie sessionId) {
@@ -99,36 +119,120 @@ public class ApiUtil {
     }
 
     public static List<GroupEntity> getGroupsListByAPI(Cookie sessionId) {
-        return getEntitiesListByAPI(sessionId, GroupEntity.class);
+        var groups = getEntitiesListByAPI(sessionId, GroupEntity.class);
+        fillConnectedEntitiesDataForGroupsList(sessionId, groups);
+
+        return groups;
+    }
+
+    public static List<TestEntity> getTestsListByAPI(Cookie sessionId) {
+        return getEntitiesListByAPIGson(sessionId, TestEntity.class);
+    }
+
+    public static <T> void verifySchemaRecords(Class<T> genericType, String filePath) {
+        given()
+                .filter(new AllureRestAssured())
+                .get(API_BASE_URI + getPathStringByEntityClass(API_ENTITY_GET_RECORDS_PATH, genericType))
+                .then()
+                .statusCode(200)
+                .body(matchesJsonSchemaInClasspath(filePath));
+    }
+
+    public static SpecialityEntity getSpecialityByID(String id, Cookie sessionId) {
+        return getEntityByAPI(id, sessionId, SpecialityEntity.class);
+    }
+
+    public static GroupEntity getGroupByID(String id, Cookie sessionId) {
+        return getEntityByAPI(id, sessionId, GroupEntity.class);
+    }
+
+    private static void fillConnectedEntitiesDataForGroupsList(Cookie sessionId, List<GroupEntity> groups) {
+        Map<String, SpecialityEntity> specialitiesCache = new HashMap<>();
+        Map<String, FacultyEntity> facultiesCache = new HashMap<>();
+        String specialityId;
+        String facultyId;
+
+        for (var group : groups) {
+            if (nonNull(group.getSpeciality())) {
+                specialityId = group
+                        .getSpeciality()
+                        .getId();
+
+                if (nonNull(specialityId)) {
+                    var speciality = specialitiesCache.computeIfAbsent(specialityId,
+                            k -> getEntityByAPI(k, sessionId, SpecialityEntity.class));
+                    group.setSpeciality(speciality);
+                }
+            }
+
+            if (nonNull(group.getFaculty())) {
+                facultyId = group
+                        .getFaculty()
+                        .getId();
+
+                if (nonNull(facultyId)) {
+                    var faculty = facultiesCache.computeIfAbsent(facultyId,
+                            k -> getEntityByAPI(k, sessionId, FacultyEntity.class));
+                    group.setFaculty(faculty);
+                }
+            }
+        }
+    }
+
+    private static <T> List<T> createEntity(Object bodyContent, Class<T> genericType) {
+        var path = getPathStringByEntityClass(API_ENTITY_POST_RECORDS_PATH, genericType);
+        var response = performPostRequestWithBody(bodyContent, path);
+
+        return extractFromJson(response).getList("", genericType);
+    }
+
+    private static <T> Response deleteEntity(String id, Cookie sessionId, Class<T> genericType) {
+        var path = getPathStringByEntityClass(API_ENTITY_DELETE_RECORDS_PATH, genericType);
+        path = format(path, id);
+
+        return performGetRequest(sessionId, path);
     }
 
     private static <T> List<T> getEntitiesListByAPI(Cookie sessionId, Class<T> genericType) {
-        var classname = genericType
-                .getSimpleName()
-                .replace("Entity", "");
-        var path = format(API_ENTITY_GET_RECORDS_PATH, classname);
+        var path = getPathStringByEntityClass(API_ENTITY_GET_RECORDS_PATH, genericType);
         var response = performGetRequest(sessionId, path);
 
         return extractFromJson(response).getList("", genericType);
     }
 
-    public static List<TestEntity> getTestsListByAPI(Cookie sessionId) {
-        var path = format(API_ENTITY_GET_RECORDS_PATH, "test");
-        var response = getJsonArrayFromGetRequest(sessionId, path);
-        var list = new LinkedList<TestEntity>();
+    private static <T> T getEntityByAPI(String id, Cookie sessionId, Class<T> genericType) {
+        var path = getPathStringByEntityClass(API_ENTITY_GET_RECORD_PATH, genericType);
+        path = format(path, id);
+        var response = performGetRequest(sessionId, path);
+        var responseValue = response
+                .getBody()
+                .jsonPath()
+                .get("response");
 
-        response.forEach(item -> list.add(new Gson().fromJson(item, TestEntity.class)));
-
-        return list;
+        if (nonNull(responseValue) && responseValue.equals("no records")) {
+            return null;
+        } else {
+            var list = extractFromJson(response).getList("", genericType);
+            return list.get(0);
+        }
     }
 
-    public static void verifySchemaRecords(String entity, String filePath) {
-        given()
-                .filter(new AllureRestAssured())
-                .get(API_BASE_URI+(format(API_ENTITY_GET_RECORDS_PATH, entity)))
-                .then()
-                .statusCode(200)
-                .body(matchesJsonSchemaInClasspath(filePath));
+    private static <T> String getPathStringByEntityClass(String pathTemplate, Class<T> genericType) {
+        var classname = genericType
+                .getSimpleName()
+                .replace("Entity", "");
+
+        return pathTemplate.replace("{Entity}", classname);
+    }
+
+    private static <T> LinkedList<T> getEntitiesListByAPIGson(Cookie sessionId, Class<T> genericType) {
+        var path = getPathStringByEntityClass(API_ENTITY_GET_RECORDS_PATH, genericType);
+        var response = getJsonArrayFromGetRequest(sessionId, path);
+        var list = new LinkedList<T>();
+
+        response.forEach(item -> list.add(new Gson().fromJson(item, genericType)));
+
+        return list;
     }
 
     private JsonArray getJsonArrayFromGetRequest(Cookie sessionId, String path) {
@@ -142,6 +246,30 @@ public class ApiUtil {
 
     private Map<String, String> setUpSubjectBody(SubjectEntity subject) {
         return of("subject_name", subject.getName(), "subject_description", subject.getDescription());
+    }
+
+    private String setUpSpecialityBody(SpecialityEntity speciality) {
+        try {
+            return new ObjectMapper().writeValueAsString(speciality);
+        } catch (JsonProcessingException e) {
+            return "";
+        }
+    }
+
+    private String setUpFacultyBody(FacultyEntity faculty) {
+        try {
+            return new ObjectMapper().writeValueAsString(faculty);
+        } catch (JsonProcessingException e) {
+            return "";
+        }
+    }
+
+    private String setUpGroupBody(GroupEntity group) {
+        try {
+            return new ObjectMapper().writeValueAsString(group);
+        } catch (JsonProcessingException e) {
+            return "";
+        }
     }
 
     private Map<String, String> setUpTimeTableBody(TimeTableEntity timeTable) {

--- a/src/main/java/com/softserveinc/ita/util/DataProvider.java
+++ b/src/main/java/com/softserveinc/ita/util/DataProvider.java
@@ -52,11 +52,12 @@ public interface DataProvider {
     String GROUP_NAME = readConfig().getString("studentsData.groupName");
     String STUDENT_IS_ADDED_SUCCESSFUL_MESSAGE = readConfig().getString("studentsData.successfulAddingMessage");
     String API_BASE_URI = readConfig().getString("api.baseUri");
-    String API_LOGIN_USER_PATH = readConfig().getString("api.basePathes.login");
-    String API_IS_LOGGED_PATH = readConfig().getString("api.basePathes.isLogged");
-    String API_LOGOUT_PATH = readConfig().getString("api.basePathes.logout");
-    String API_ENTITY_GET_RECORDS_PATH = readConfig().getString("api.entityPathes.getRecords");
-    String API_ENTITY_POST_RECORDS_PATH = readConfig().getString("api.entityPathes.insertData");
-    String API_ENTITY_UPDATE_RECORDS_PATH = readConfig().getString("api.entityPathes.update");
-    String API_ENTITY_DELETE_RECORDS_PATH = readConfig().getString("api.entityPathes.delete");
+    String API_LOGIN_USER_PATH = readConfig().getString("api.basePaths.login");
+    String API_IS_LOGGED_PATH = readConfig().getString("api.basePaths.isLogged");
+    String API_LOGOUT_PATH = readConfig().getString("api.basePaths.logout");
+    String API_ENTITY_GET_RECORDS_PATH = readConfig().getString("api.entityPaths.getRecords");
+    String API_ENTITY_GET_RECORD_PATH = readConfig().getString("api.entityPaths.getRecord");
+    String API_ENTITY_POST_RECORDS_PATH = readConfig().getString("api.entityPaths.insertData");
+    String API_ENTITY_UPDATE_RECORDS_PATH = readConfig().getString("api.entityPaths.update");
+    String API_ENTITY_DELETE_RECORDS_PATH = readConfig().getString("api.entityPaths.delete");
 }

--- a/src/main/java/com/softserveinc/ita/util/RandomUtil.java
+++ b/src/main/java/com/softserveinc/ita/util/RandomUtil.java
@@ -1,7 +1,6 @@
 package com.softserveinc.ita.util;
 
 import lombok.experimental.UtilityClass;
-import org.apache.commons.lang3.RandomStringUtils;
 
 import static org.apache.commons.lang3.RandomStringUtils.*;
 
@@ -10,6 +9,11 @@ public class RandomUtil {
 
     public static String getRandomStringWithLetters(int length) {
         return randomAlphabetic(length);
+    }
+
+    public static String getRandomStringWithCyrillicLetters(int length) {
+        var allowedCharacters = "АБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя";
+        return random(length, allowedCharacters);
     }
 
     public static String getRandomStringWithNumbers(int length) {

--- a/src/main/java/com/softserveinc/ita/util/RandomUtil.java
+++ b/src/main/java/com/softserveinc/ita/util/RandomUtil.java
@@ -13,6 +13,7 @@ public class RandomUtil {
 
     public static String getRandomStringWithCyrillicLetters(int length) {
         var allowedCharacters = "АБВГҐДЕЄЖЗИІЇЙКЛМНОПРСТУФХЦЧШЩЬЮЯабвгґдеєжзиіїйклмнопрстуфхцчшщьюя";
+
         return random(length, allowedCharacters);
     }
 

--- a/src/main/resources/data.conf
+++ b/src/main/resources/data.conf
@@ -22,16 +22,17 @@ messages {
 }
 api{
   baseUri = "https://dtapi.if.ua/api"
-  basePathes{
+  basePaths{
     login = "/login"
     isLogged = "/login/isLogged"
     logout = "/login/logout"
   }
-  entityPathes{
-    getRecords = "/%s/getRecords"
-    insertData = "/%s/insertData"
-    update = "/%s/update/%s"
-    delete = "/%s/del/%s"
+  entityPaths{
+    getRecords = "/{Entity}/getRecords"
+    getRecord = "/{Entity}/getRecords/%s"
+    insertData = "/{Entity}/insertData"
+    update = "/{Entity}/update/%s"
+    delete = "/{Entity}/del/%s"
   }
 }
 testData{

--- a/src/test/java/com/softserveinc/ita/ApiJsonSchemaTest.java
+++ b/src/test/java/com/softserveinc/ita/ApiJsonSchemaTest.java
@@ -1,5 +1,6 @@
 package com.softserveinc.ita;
 
+import com.softserveinc.ita.models.TestEntity;
 import io.qameta.allure.Description;
 import io.restassured.http.Cookie;
 import org.testng.annotations.AfterClass;
@@ -22,9 +23,9 @@ public class ApiJsonSchemaTest {
     }
 
     @Test(groups = "positive")
-    @Description("Test to verify corectness of the json schema of tests entities")
+    @Description("Test to verify correctness of the json schema of tests entities")
     public void verifyTestEntitySchemaRecords() {
-        verifySchemaRecords("test", "schemas/TestGetRecordsSchema200.json");
+        verifySchemaRecords(TestEntity.class, "schemas/TestGetRecordsSchema200.json");
     }
 
     @AfterClass

--- a/src/test/java/com/softserveinc/ita/GroupsTest.java
+++ b/src/test/java/com/softserveinc/ita/GroupsTest.java
@@ -127,7 +127,7 @@ public class GroupsTest extends TestRunner {
 
         assertThat(lastGroupName)
                 .as("After editing group last group in the table should have name after edit")
-                .isEqualTo(group.getName());
+                 .isEqualTo(group.getName());
     }
 
     @AfterClass

--- a/src/test/java/com/softserveinc/ita/GroupsTest.java
+++ b/src/test/java/com/softserveinc/ita/GroupsTest.java
@@ -12,21 +12,19 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.List;
-
 import static com.codeborne.selenide.Selenide.refresh;
+import static com.softserveinc.ita.util.ApiUtil.getGroupsListByAPI;
 import static com.softserveinc.ita.util.ApiUtil.performGetRequest;
 import static com.softserveinc.ita.util.AuthApiUtil.authAsAdmin;
 import static com.softserveinc.ita.util.AuthApiUtil.getSessionsCookie;
-import static com.softserveinc.ita.util.DataProvider.*;
+import static com.softserveinc.ita.util.DataProvider.API_LOGOUT_PATH;
+import static com.softserveinc.ita.util.DataProvider.GROUPS_PAGE_URL;
 import static com.softserveinc.ita.util.WindowTabHelper.getCurrentUrl;
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GroupsTest extends TestRunner {
 
     private GroupsPage groupsPage;
-
     private Cookie sessionId;
     private SpecialityEntity speciality;
     private FacultyEntity faculty;
@@ -38,11 +36,13 @@ public class GroupsTest extends TestRunner {
 
         speciality = SpecialityEntity
                 .builder()
+                .id("1")
                 .name("Автоматизація та компютерно-інтегровані технології")
                 .build();
 
         faculty = FacultyEntity
                 .builder()
+                .id("1")
                 .name("Інститут інформаційних технологій")
                 .build();
     }
@@ -70,11 +70,11 @@ public class GroupsTest extends TestRunner {
     public void verifyAddingNewGroup() {
         var group = GroupEntity.getNewValidGroup(speciality, faculty);
 
-        var groups = getGroupsListByAPI();
+        var groups = getGroupsListByAPI(sessionId);
 
         assertThat(groups)
                 .as("Before adding new group it shouldn't be present in the list of groups returned by API call")
-                .doesNotContain(group.getName());
+                .doesNotContain(group);
 
         groupsStep.addNewGroup(group);
 
@@ -89,11 +89,11 @@ public class GroupsTest extends TestRunner {
                 .isEqualTo(group.getName());
 
 
-        groups = getGroupsListByAPI();
+        groups = getGroupsListByAPI(sessionId);
 
         soft.assertThat(groups)
                 .as("After adding new group it should be present in the list of groups returned by API call")
-                .contains(group.getName());
+                .contains(group);
 
         soft.assertAll();
 
@@ -107,11 +107,11 @@ public class GroupsTest extends TestRunner {
 
         groupsStep.addNewGroup(group);
 
-        var groups = getGroupsListByAPI();
+        var groups = getGroupsListByAPI(sessionId);
 
         assertThat(groups)
                 .as("After adding new group it should be present in the list of groups returned by API call")
-                .contains(group.getName());
+                .contains(group);
 
         groupsStep.deleteGroup(group);
 
@@ -125,11 +125,11 @@ public class GroupsTest extends TestRunner {
                         "should not have deleted name")
                 .isNotEqualTo(group.getName());
 
-        groups = getGroupsListByAPI();
+        groups = getGroupsListByAPI(sessionId);
 
         soft.assertThat(groups)
                 .as("After deleting group it shouldn't be present in the list of groups returned by API call")
-                .doesNotContain(group.getName());
+                .doesNotContain(group);
 
         soft.assertAll();
     }
@@ -137,15 +137,5 @@ public class GroupsTest extends TestRunner {
     @AfterClass
     public void tearDown() {
         performGetRequest(sessionId, API_LOGOUT_PATH);
-    }
-
-    private List<Object> getGroupsListByAPI() {
-        var path = format(API_ENTITY_GET_RECORDS_PATH, "group");
-        var response = performGetRequest(sessionId, path);
-
-        return response
-                .getBody()
-                .jsonPath()
-                .getList("group_name");
     }
 }


### PR DESCRIPTION
refactored API methods to avoid boilerplate code
fixed problem with confirm button click while adding
made possible to send API post requests with String instead of Map
added method to create valid FacultyEntity with random field values
added method to get API record for one entity
added custom serializer/deserializer for GroupEntity and method that allows filling connected data from API
changed test logic in order to use UI methods only for test steps, while using API for setting up and tearing down part 
minor changes: spelling mistakes corrected